### PR TITLE
Added support for newsboat

### DIFF
--- a/common/profile-cleaner.in
+++ b/common/profile-cleaner.in
@@ -258,6 +258,12 @@ case "$1" in
     fi
     exit 0
     ;;
+  n|N)
+    name="newsboat"; export name
+    prepath="$XDG_DATA_HOME"/$name
+    do_dbbased
+    exit 0
+    ;;
   o|O|on|ON|od|OD|ob|OB)
     for name in opera opera-next opera-developer opera-beta; do
       if [[ -d "$XDG_CONFIG_HOME"/$name ]]; then
@@ -400,7 +406,7 @@ case "$1" in
       echo -e "  ${BLD}id) ${GRN}i${NRM}${BLD}ce${GRN}d${NRM}${BLD}ove${NRM}"
       echo -e "  ${BLD}ix) ${GRN}i${NRM}${BLD}no${GRN}x${NRM}"
       echo -e "   ${BLD}m) ${GRN}m${NRM}${BLD}idori${NRM}"
-      echo -e "   ${BLD}n) ${GRN}n${NRM}${BLD}ewsbeuter${NRM}"
+      echo -e "   ${BLD}n) ${GRN}n${NRM}${BLD}ewsboat${NRM}"
       echo -e "  ${BLD}pm) ${GRN}p${NRM}${BLD}ale${GRN}m${NRM}${BLD}oon${NRM}"
       echo -e "   ${BLD}q) ${GRN}q${NRM}${BLD}upZilla${NRM}"
       echo -e "   ${BLD}s) ${GRN}s${NRM}${BLD}eamonkey${NRM}"

--- a/common/zsh-completion
+++ b/common/zsh-completion
@@ -15,7 +15,7 @@ _pc() {
 		'id:IceDove'
 		'ix:InoX'
 		'm:Midori'
-		'n:Newsbeuter'
+		'n:Newsboat'
 		'o:Opera (stable, next, and developer)'
 		'pm:PaleMoon'
 		'q:QupZilla'

--- a/doc/pc.1
+++ b/doc/pc.1
@@ -152,7 +152,7 @@ Inox (https://bbs.archlinux.org/viewtopic.php?id=198763)
 .IP \(bu 3
 Midori
 .IP \(bu 3
-Newsbeuter
+Newsboat
 .IP \(bu 3
 Opera (stable, next, and developer)
 .IP \(bu 3


### PR DESCRIPTION
Hi Graysky,

Thank you for this awesome script. I discovered profile cleaner only today. As far as I can see, there was support for [newsbeuter](https://github.com/akrennmair/newsbeuter) at some point, but that has been abandoned. I decided to replace this with support for [newsboat](https://github.com/newsboat/newsboat) and submit a pull request.  Feedback is more than welcome. 

[edit]: I noticed the paths option. This one apparently cleans up my NB config as well. Is this just a catch-all option and if so, does it make sense to offer newsboat as a separate option? If not, please deny the pull request. 

Kind regards,
derjoachim