### PR TITLE
check default newsboat dotdir

### DIFF
--- a/common/profile-cleaner.in
+++ b/common/profile-cleaner.in
@@ -260,7 +260,11 @@ case "$1" in
     ;;
   n|N)
     name="newsboat"; export name
-    prepath="$XDG_DATA_HOME"/$name
+    if [[ -d "$HOME"/.$name ]]; then
+      prepath="$HOME"/.$name
+    else
+      prepath="$XDG_DATA_HOME"/$name
+    fi
     do_dbbased
     exit 0
     ;;


### PR DESCRIPTION
As per the final comment of [PR 35](https://github.com/graysky2/profile-cleaner/pull/35) and the [official docs](https://newsboat.org/releases/2.25/docs/newsboat.html#_files), the script will now check the default `.newsboat` directory first, before looking in `$XDG_DATA_HOME`. Apparently, I migrated to the latter at some point in the past. 